### PR TITLE
MSYS-823 : Fixes of Pathname.parent for root directory

### DIFF
--- a/lib/win32/file.rb
+++ b/lib/win32/file.rb
@@ -60,7 +60,7 @@ class File
 
     # Return a root path as-is.
     if PathIsRootW(wfile)
-      return file.tr(File::SEPARATOR, File::ALT_SEPARATOR)
+      return file.tr(File::ALT_SEPARATOR, File::SEPARATOR)
     end
 
     ptr = FFI::MemoryPointer.from_string(wfile)

--- a/test/test_win32_file_path.rb
+++ b/test/test_win32_file_path.rb
@@ -33,14 +33,14 @@ class TC_Win32_File_Path < Test::Unit::TestCase
     assert_equal("bar", File.basename("C:\\foo\\bar"))
     assert_equal("bar", File.basename("C:\\foo\\bar\\"))
     assert_equal("foo", File.basename("C:\\foo"))
-    assert_equal("C:\\", File.basename("C:\\"))
+    assert_equal("C:/", File.basename("C:\\"))
   end
 
   test "basename method handles unc paths" do
     assert_equal("baz.txt", File.basename("\\\\foo\\bar\\baz.txt"))
     assert_equal("baz", File.basename("\\\\foo\\bar\\baz"))
-    assert_equal("\\\\foo", File.basename("\\\\foo"))
-    assert_equal("\\\\foo\\bar", File.basename("\\\\foo\\bar"))
+    assert_equal("//foo", File.basename("\\\\foo"))
+    assert_equal("//foo/bar", File.basename("\\\\foo\\bar"))
   end
 
   test "basename method handles forward slashes in standard unix paths" do
@@ -53,15 +53,15 @@ class TC_Win32_File_Path < Test::Unit::TestCase
   end
 
   test "basename method handles forward slashes in unc unix paths" do
-    assert_equal("\\\\foo", File.basename("//foo"))
-    assert_equal("\\\\foo\\bar", File.basename("//foo/bar"))
+    assert_equal("//foo", File.basename("//foo"))
+    assert_equal("//foo/bar", File.basename("//foo/bar"))
   end
 
   test "basename method handles forward slashes in windows paths" do
     assert_equal("bar", File.basename("C:/foo/bar"))
     assert_equal("bar", File.basename("C:/foo/bar/"))
     assert_equal("foo", File.basename("C:/foo"))
-    assert_equal("C:\\", File.basename("C:/"))
+    assert_equal("C:/", File.basename("C:/"))
     assert_equal("bar", File.basename("C:/foo/bar//"))
   end
 


### PR DESCRIPTION
**Description:**

Fixed issue default behavior of ::Pathname.parent() on Windows is changed

**Issue**

Fixes https://github.com/chef/win32-file/issues/8

Signed-off-by: piyushawasthi <piyush.awasthi@msystechnologies.com>